### PR TITLE
Add account and email fields + help for time

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -13,6 +13,12 @@ attributes:
     widget: "text_field"
     label: "Running time [format: dd-hh:mm:ss]"
     value: "03:00:00"
+    help: |
+      Keep in mind the time limit of each partition:
+      - debug-cpu is max 15 minutes
+      - shared-cpu is max 12 hours
+      - public-cpu is max 4 days
+      - ... More info on https://doc.eresearch.unige.ch/hpc/slurm#which_partition_for_my_job
 
   mem_gb:
     widget: "number_field"

--- a/form.yml
+++ b/form.yml
@@ -7,6 +7,7 @@ form:
   - mem_gb
   - cpus
   - my_account
+  - my_email
 attributes:
   time:
     widget: "text_field"

--- a/form.yml
+++ b/form.yml
@@ -6,6 +6,7 @@ form:
   - time
   - mem_gb
   - cpus
+  - my_account
 attributes:
   time:
     widget: "text_field"
@@ -39,6 +40,18 @@ attributes:
       - `docker://unigebsp/ngs`
       - `docker://bioconductor/bioconductor_docker:RELEASE_3_18`
       - `docker://rocker/rstudio:4.3.2`
+
+  my_account:
+    widget: "text_field"
+    label: "Account to charge for this job"
+    value: ""
+    help: "Leave it empty if you want to use your default account."
+
+  my_email:
+    widget: "text_field"
+    label: "Email address to write to when the job start"
+    value: ""
+    help: "Leave it empty if you don't want to receive any email."
 
   # image:
   #   widget: select

--- a/form.yml
+++ b/form.yml
@@ -15,6 +15,7 @@ attributes:
     value: "03:00:00"
     help: |
       Keep in mind the time limit of each partition:
+      
       - debug-cpu is max 15 minutes
       - shared-cpu is max 12 hours
       - public-cpu is max 4 days

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -17,5 +17,13 @@ script:
     - "<%= time %>"
     - "--signal"
     - "USR2"
-
-
+    <%- unless my_account.blank? -%>
+    - "--account"
+    - "<%= my_account %>"
+    <%- end -%>
+    <%- unless my_email.blank? -%>
+    - "--mail-type"
+    - "BEGIN"
+    - "--mail-user"
+    - "<%= my_email %>"
+    <%- end -%>


### PR DESCRIPTION
New options that could be useful to users:
- set the account if you want to use the non-default one
- set the email if you want to receive an email when your job starts

I tested it and it seemed to work.

I tried to improve help for the running time because the issue is that if you ask for a larger time that possible your job just get pending with reason: "PartitionTimeLimit" but you don't get any warning for this so you can wait forever...